### PR TITLE
Update composer.json Laravel 10.x Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "^8.0|^8.1",
         "filament/forms": "^2.16",
-        "illuminate/contracts": "^9.0",
+        "illuminate/contracts": "^9.0|^10.0",
         "spatie/laravel-package-tools": "^1.13.0",
         "jantinnerezo/livewire-range-slider": "dev-main"
     },


### PR DESCRIPTION
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - nettantra/filament-slider-input-field[v0.0.1, ..., v0.0.4] require illuminate/contracts ^9.0 -> found illuminate/contracts[v9.0.0, ..., v9.52.7] but these were not loaded, likely because it conflicts with another require.
    - Root composer.json requires nettantra/filament-slider-input-field * -> satisfiable by nettantra/filament-slider-input-field[v0.0.1, v0.0.2, v0.0.3, v0.0.4].

You can also try re-running composer require with an explicit version constraint, e.g. "composer require nettantra/filament-slider-input-field:*" to figure out if any version is installable, or "composer require nettantra/filament-slider-input-field:^2.1" if you know which you need.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.